### PR TITLE
backport patch to unbreak grpc

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,9 +7,13 @@ package:
 source:
   url: https://c-ares.haxx.se/download/c-ares-{{ version }}.tar.gz
   sha256: de24a314844cb157909730828560628704f4f896d167dd7da0fa2fb93ea18b10
+  patches:
+    # backport so-far unreleased commit because c-ares 1.20 broke grpc, see
+    # https://github.com/c-ares/c-ares/commit/a070d7835d667b2fae5266fe1b790677dae47d25
+    - patches/0001-Socket-callbacks-were-passed-SOCK_STREAM-instead-of-.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: c-ares

--- a/recipe/patches/0001-Socket-callbacks-were-passed-SOCK_STREAM-instead-of-.patch
+++ b/recipe/patches/0001-Socket-callbacks-were-passed-SOCK_STREAM-instead-of-.patch
@@ -1,0 +1,58 @@
+From eabc1785ea2ca153f019ac3931bbf75c9955c3ab Mon Sep 17 00:00:00 2001
+From: Brad House <brad@brad-house.com>
+Date: Thu, 12 Oct 2023 09:29:14 -0400
+Subject: [PATCH] Socket callbacks were passed SOCK_STREAM instead of
+ SOCK_DGRAM on udp
+
+A regression was introduced in 1.20.0 that would pass SOCK_STREAM on udp
+connections due to code refactoring.  If a client application validated this
+data, it could cause issues as seen in gRPC.
+
+Fixes Issue: #571
+Fix By: Brad House (@bradh352)
+---
+ src/lib/ares_process.c | 10 ++++------
+ 1 file changed, 4 insertions(+), 6 deletions(-)
+
+diff --git a/src/lib/ares_process.c b/src/lib/ares_process.c
+index 06e7121..536d74f 100644
+--- a/src/lib/ares_process.c
++++ b/src/lib/ares_process.c
+@@ -1065,6 +1065,7 @@ static int open_socket(ares_channel channel, struct server_state *server,
+   unsigned short port;
+   struct server_connection *conn;
+   ares__llist_node_t *node;
++  int type = is_tcp?SOCK_STREAM:SOCK_DGRAM;
+ 
+   if (is_tcp) {
+     port = aresx_sitous(server->addr.tcp_port?
+@@ -1098,8 +1099,7 @@ static int open_socket(ares_channel channel, struct server_state *server,
+   }
+ 
+   /* Acquire a socket. */
+-  s = ares__open_socket(channel, server->addr.family,
+-                        is_tcp?SOCK_STREAM:SOCK_DGRAM, 0);
++  s = ares__open_socket(channel, server->addr.family, type, 0);
+   if (s == ARES_SOCKET_BAD)
+     return ARES_ECONNREFUSED;
+ 
+@@ -1129,8 +1129,7 @@ static int open_socket(ares_channel channel, struct server_state *server,
+ #endif
+ 
+   if (channel->sock_config_cb) {
+-    int err = channel->sock_config_cb(s, SOCK_STREAM,
+-                                      channel->sock_config_cb_data);
++    int err = channel->sock_config_cb(s, type, channel->sock_config_cb_data);
+     if (err < 0) {
+       ares__close_socket(channel, s);
+       return ARES_ECONNREFUSED;
+@@ -1148,8 +1147,7 @@ static int open_socket(ares_channel channel, struct server_state *server,
+   }
+ 
+   if (channel->sock_create_cb) {
+-    int err = channel->sock_create_cb(s, SOCK_STREAM,
+-                                      channel->sock_create_cb_data);
++    int err = channel->sock_create_cb(s, type, channel->sock_create_cb_data);
+     if (err < 0) {
+       ares__close_socket(channel, s);
+       return ARES_ECONNREFUSED;


### PR DESCRIPTION
This also [breaks](https://github.com/apache/arrow/issues/38280) arrow, where @xshirax did the [lion's share](https://github.com/apache/arrow/issues/38280#issuecomment-1772731496) of tracking down the cause & patch. It doesn't look like c-ares will release again soon, so fix it with a backport