### PR TITLE
Use glibc 2.17 again

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,15 +11,15 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-alma-x86_64:8
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_:
         CONFIG: linux_aarch64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-alma-x86_64:8
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_ppc64le_:
         CONFIG: linux_ppc64le_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-alma-x86_64:8
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.28'
+- '2.17'
 cdt_name:
 - conda
 channel_sources:
@@ -13,6 +13,6 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-alma-x86_64:8
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 target_platform:
 - linux-64

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -7,7 +7,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.28'
+- '2.17'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,6 +17,6 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-alma-x86_64:8
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 target_platform:
 - linux-aarch64

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.28'
+- '2.17'
 cdt_name:
 - conda
 channel_sources:
@@ -13,6 +13,6 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-alma-x86_64:8
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 target_platform:
 - linux-ppc64le

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -34,8 +34,8 @@ call "%MICROMAMBA_EXE%" create --yes --root-prefix "%MAMBA_ROOT_PREFIX%" --prefi
     pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 if !errorlevel! neq 0 exit /b !errorlevel!
 echo Removing %MAMBA_ROOT_PREFIX%
-del /S /Q "%MAMBA_ROOT_PREFIX%"
-del /S /Q "%MICROMAMBA_TMPDIR%"
+del /S /Q "%MAMBA_ROOT_PREFIX%" >nul
+del /S /Q "%MICROMAMBA_TMPDIR%" >nul
 
 call :start_group "Configuring conda"
 

--- a/build-locally.py
+++ b/build-locally.py
@@ -26,6 +26,13 @@ def setup_environment(ns):
             os.path.dirname(__file__), "miniforge3"
         )
 
+    # The default cache location might not be writable using docker on macOS.
+    if ns.config.startswith("linux") and platform.system() == "Darwin":
+        os.environ["CONDA_FORGE_DOCKER_RUN_ARGS"] = (
+            os.environ.get("CONDA_FORGE_DOCKER_RUN_ARGS", "")
+            + " -e RATTLER_CACHE_DIR=/tmp/rattler_cache"
+        )
+
 
 def run_docker_build(ns):
     script = ".scripts/run_docker_build.sh"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,7 +1,2 @@
-c_stdlib_version:                                   # [linux]
-  - "2.28"                                          # [linux]
-docker_image:                                       # [linux]
-  - quay.io/condaforge/linux-anvil-alma-x86_64:8    # [linux]
-
 MACOSX_SDK_VERSION:  # [osx and x86_64]
   - "10.15"          # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 26e1f7771da23e42a18fdf1e58912a396629e53a2ac71b130af93bbcfb90adbe
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: c-ares


### PR DESCRIPTION
We hadn't documented in #38 why we moved to 2.28, and I forgot the reason (also, the CI logs are no longer there). So double-check what goes wrong with 2.17.